### PR TITLE
chore: reduce build time warnings

### DIFF
--- a/access-datastore-api/build.gradle
+++ b/access-datastore-api/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 
 sourceSets.main.java.srcDirs += ['generated/src/main/java']
 
-checkstyleMain.exclude "*"
+checkstyleMain.exclude("*")
 
 openApiGenerate {
     generatorName = "spring"
@@ -38,10 +38,10 @@ openApiGenerate {
     ]
 }
 
-compileJava.dependsOn 'openApiGenerate'
+compileJava.dependsOn('openApiGenerate')
 
 clean {
-    delete "$rootDir/access-datastore-api/generated"
+    delete("$rootDir/access-datastore-api/generated")
 }
 
 // disable for overall project when running a build

--- a/access-datastore-service/build.gradle
+++ b/access-datastore-service/build.gradle
@@ -1,17 +1,18 @@
 plugins {
     id 'io.freefair.lombok' version '8.13'
+    id "com.gorylenko.gradle-git-properties" version "2.4.1"
     id 'uk.gov.laa.ccms.springboot.laa-ccms-spring-boot-gradle-plugin'
 }
 
 test {
     useJUnitPlatform()
-    finalizedBy jacocoTestReport
+    finalizedBy(jacocoTestReport)
 }
 
 jacocoTestReport {
     afterEvaluate {
         classDirectories.setFrom(files(classDirectories.files.collect {
-            fileTree(dir: it, exclude: ['**/SpringBootMicroserviceApplication.class'])
+            fileTree(dir: it, exclude: ['**/AccessDatastoreApplication.class'])
         }))
     }
 }
@@ -19,7 +20,7 @@ jacocoTestReport {
 jacocoTestCoverageVerification {
     afterEvaluate {
         classDirectories.setFrom(files(classDirectories.files.collect {
-            fileTree(dir: it, exclude: ['**/SpringBootMicroserviceApplication.class'])
+            fileTree(dir: it, exclude: ['**/AccessDatastoreApplication.class'])
         }))
     }
 }

--- a/access-datastore-service/src/main/java/uk/gov/justice/laa/access/datastore/mapper/ApplicationMapper.java
+++ b/access-datastore-service/src/main/java/uk/gov/justice/laa/access/datastore/mapper/ApplicationMapper.java
@@ -15,6 +15,7 @@ import uk.gov.justice.laa.access.datastore.model.Application;
 import uk.gov.justice.laa.access.datastore.model.ApplicationHistoryEntry;
 import uk.gov.justice.laa.access.datastore.model.ApplicationProceeding;
 import uk.gov.justice.laa.access.datastore.model.ApplicationProceedingRequestBody;
+import uk.gov.justice.laa.access.datastore.model.ApplicationProceedingUpdateRequestBody;
 import uk.gov.justice.laa.access.datastore.model.ApplicationRequestBody;
 import uk.gov.justice.laa.access.datastore.model.ApplicationUpdateRequestBody;
 
@@ -39,6 +40,7 @@ public interface ApplicationMapper {
    * @return the application entity
    */
   @Mapping(target = "id", ignore = true)
+  @Mapping(target = "proceedings", ignore = true)
   @Mapping(target = "recordHistory", ignore = true)
   ApplicationEntity toApplicationEntity(ApplicationRequestBody applicationRequestBody);
 
@@ -49,14 +51,32 @@ public interface ApplicationMapper {
    * @param applicationUpdateRequestBody the application update request
    */
   @BeanMapping(nullValuePropertyMappingStrategy =  NullValuePropertyMappingStrategy.IGNORE)
+  @Mapping(target = "id", ignore = true)
+  @Mapping(target = "proceedings", ignore = true)
+  @Mapping(target = "recordHistory", ignore = true)
   void updateApplicationEntity(
       @MappingTarget ApplicationEntity applicationEntity,
       ApplicationUpdateRequestBody applicationUpdateRequestBody);
 
   @BeanMapping(nullValuePropertyMappingStrategy =  NullValuePropertyMappingStrategy.IGNORE)
+  @Mapping(target = "id", ignore = true)
+  @Mapping(target = "createdAt", ignore = true)
+  @Mapping(target = "createdBy", ignore = true)
+  @Mapping(target = "updatedAt", ignore = true)
+  @Mapping(target = "updatedBy", ignore = true)
   void updateApplicationEntity(
       @MappingTarget Application application,
       ApplicationUpdateRequestBody applicationUpdateRequestBody);
+
+  /**
+   * This mapping exists solely so we can declare the ignored fields, to avoid a warning on the
+   * updateApplicationEntity mapping method which targets an Application instance.
+   */
+  @Mapping(target = "createdAt", ignore = true)
+  @Mapping(target = "createdBy", ignore = true)
+  @Mapping(target = "updatedAt", ignore = true)
+  @Mapping(target = "updatedBy", ignore = true)
+  ApplicationProceeding toApplicationProceeding(ApplicationProceedingUpdateRequestBody applicationProceedingUpdateRequestBody);
 
   ApplicationHistoryEntry toApplicationHistoryEntry(
       ApplicationHistoryEntity applicationHistoryEntity);


### PR DESCRIPTION
- use explicit Groovy DSL method calls, to help find old-style setter warning
- add git properties Gradle plugin to augment the info actuator
- fix excluded Jacoco class name
- fix MapperStruct warnings for generated mappings

references DSTEW-35